### PR TITLE
tools: addr2src: add initial addr2src tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,27 @@
 A collection of [Zephyr](https://zephyrproject.org/) `west`
 [extensions](https://docs.zephyrproject.org/latest/develop/west/extensions.html)
 for convenient debugging.
+
+## Install
+
+`west dbt` can be added to any Zephyr project by adding the following to the
+`west.yml` manifest file.
+
+```yaml
+    - name: west-debug-tools
+      revision: main
+      url: https://github.com/hasheddan/west-debug-tools
+      west-commands: west-commands.yml
+```
+
+## Tools
+
+The following tools are currently supported.
+
+### `addr2src`
+
+Emits the file path, line number, and source at the specified address.
+
+```
+west dbt addr2src <address>
+```

--- a/dbt.py
+++ b/dbt.py
@@ -1,0 +1,46 @@
+from textwrap import dedent
+
+from west.commands import WestCommand
+
+from tools.addr2src import addr2src
+
+
+class DebugTools(WestCommand):
+    def __init__(self):
+        super().__init__(
+            "dbt",
+            "Convenient debugging tools.",
+            dedent(
+                """
+                dbt is a collection of tools that make debugging Zephyr
+                applications more convenient.
+                """
+            ),
+        )
+
+    def do_add_parser(self, parser_adder):
+        parser = parser_adder.add_parser(
+            self.name, help=self.help, description=self.description
+        )
+        subparsers = parser.add_subparsers(
+            metavar="<subcommand>",
+            dest="subcommand",
+            help="Select a subcommand.",
+        )
+        addr2src_parser = subparsers.add_parser(
+            "addr2src",
+            help="Emit file, line number, and source for address.",
+            epilog=dedent(
+                """
+                Emits the file path, line number, and source at the specified
+                address.
+                """
+            ),
+        )
+        addr2src_parser.add_argument("address", help="Instruction address.")
+
+        return parser
+
+    def do_run(self, args, unknown_args):
+        cmd = addr2src(self.topdir, self.config.get("zephyr.base"), args.address)
+        self.check_call(cmd, **{})

--- a/tools/addr2src.py
+++ b/tools/addr2src.py
@@ -1,0 +1,24 @@
+import os
+import importlib
+import importlib.util
+import sys
+
+ZCMAKE_PATH = "scripts/west_commands/zcmake.py"
+
+
+def addr2src(topdir, zephyr_base, address):
+    spec = importlib.util.spec_from_file_location(
+        "zcmake",
+        os.path.join(topdir, zephyr_base, ZCMAKE_PATH),
+    )
+    zcmake = importlib.util.module_from_spec(spec)
+    sys.modules["zcmake"] = zcmake
+    spec.loader.exec_module(zcmake)
+    cache = zcmake.CMakeCache.from_build_dir("build")
+    return (
+        [cache.get("CMAKE_GDB")]
+        + ["-q"]
+        + [cache.get("BYPRODUCT_KERNEL_ELF_NAME")]
+        + ["-ex", f"list *{address}"]
+        + ["-ex", "quit"]
+    )

--- a/west-commands.yml
+++ b/west-commands.yml
@@ -1,0 +1,6 @@
+west-commands:
+  - file: dbt.py
+    commands:
+      - name: dbt
+        class: DebugTools
+        help: Convenient debugging tools.

--- a/west.yml
+++ b/west.yml
@@ -1,0 +1,3 @@
+manifest:
+  self:
+    west-commands: west-commands.yml


### PR DESCRIPTION
Adds an addr2src tool that takes an address and uses gdb to emit file,
line number, and source.

Note that this implementation does not support multi-domain builds. When
implemented, it should be done so in a generic manner such that it can
be used across tools.

Signed-off-by: Daniel Mangum <georgedanielmangum@gmail.com>